### PR TITLE
Support fancy markdown slides, and image credit statements

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -33,17 +33,42 @@
     height: auto;
     visibility: visible; }
 
-@media screen {
-.reveal .slides section.present note {
+imgcredit {
+  text-align: left;
+  display: block;
+  font-size: 30% ! important;
+  color: #ccc;
+  transform: rotate(-90deg);
+  transform-origin: top left;
+  position: fixed;
+  padding-left: 50px;
+}
+
+imgcredit::before {
+  content: "Image credit: ";
+}
+
+@media print {
+imgcredit
+{
+  position: absolute;
+}
+}
+
+
+.reveal .slides section.present p note,
+.reveal .slides section.present note
+{
   position: fixed;
   bottom: 0px;
+  left: 0px;
   font-size: 60%;
   text-align: left;
   display: block;
 }
-}
 
 @media print {
+.reveal .slides section.present p note,
 .reveal .slides section.present note {
   position: absolute;
   font-size: 40%;

--- a/talks/teaser_reproducible_paper.html
+++ b/talks/teaser_reproducible_paper.html
@@ -33,26 +33,38 @@
 
 
 
-<section>
-    <h3> A reproducible paper?</h3>
-    <p class="fragment fade-in" align="left"><br>
-        <i>Reproducible</i>, as defined first by Claebout & Karrenbach (1992):<br><br>
-    <q>Authors provide all the necessary <b>data</b> and the <b>computer codes</b> to run the analysis again, re-creating the results.
-    </q><br><br>
-    </p>
-    <p class="fragment fade-in" align="left"><br>
-        My talk is a demonstration of <a href="https://github.com/psychoinformatics-de/paper-remodnav" target="_blank">a reproducible paper</a>,
-        and its advantages.
-    </p>
- </section>
+<section data-markdown><script type="text/template">
+## A reproducible paper?
+*Reproducible*, as defined first by Claebout & Karrenbach (1992):
+<!-- .element: class="fragment fade-in" align="left" data-fragment-index="1" -->
+
+> Authors provide all the necessary **data** and the **computer codes**
+  to run the analysis again, re-creating the results.
+<!-- .element: class="fragment fade-in" align="left" data-fragment-index="1" -->
+
+My talk is a demonstration of
+https://github.com/psychoinformatics-de/paper-remodnav, a reproducible paper,
+and its advantages.
+<!-- .element: class="fragment fade-in" align="left" data-fragment-index="2" -->
+</script></section>
 
 
-<section>
-    <h2>What are the advantages?</h2>
-    <br>
-    <img data-src="../pics/noun_benefit.svg" width="250">
-    <br><br><br>
-    <note><small>benefit by alvianwijaya from the Noun Project</small></note>
+<section data-markdown><script type="text/template">
+## What are the advantages?
+
+![](../pics/noun_benefit.svg)<!-- .element: width="250" -->
+
+- maybe
+- a few
+- keywords
+
+<note>some additional info or reference</note>
+<imgcredit>benefit by alvianwijaya from the Noun Project</imgcredit>
+
+<aside class="notes">
+Anything inside this tag is put into the speaker notes.
+</aside>
+</script>
 </section>
 
 


### PR DESCRIPTION
The code for the two converted slides looks pretty complicated, and one could argue that the html version is just simpler. However, that is only because the result tries to be feature equivalent with the previous HTML version.  When cranking out slides for lectures the desire is often to tweak as little as possible, and I quickly stick to the default components: images, lists, enumerations, code snippets and math. When sticking to those bits that are well defined in markdown, the time it takes to compose a slide in markdown (just the typing) is massively reduced, and the focus is on the content, not the markup and layout.

I added default formatting of image credit statements (via a custom tag). Those are important, but they are not the primary content of a slide, hence I made them less visible and off to the side. The dedicated tag marks those statements up semantically, and different from a general slide note (which are useful for citations and other references related to the primary message of a slide).

Note, doing some/all slides with markdown is completely optional and can be decided on a case by case basis, depending on the customization demand.